### PR TITLE
Add Cancel Button to RemoveItemFromContainerActivity

### DIFF
--- a/app/src/main/java/camp/letsbuild/inventoryscanner/RemoveItemFromContainerActivity.kt
+++ b/app/src/main/java/camp/letsbuild/inventoryscanner/RemoveItemFromContainerActivity.kt
@@ -65,6 +65,10 @@ class RemoveItemFromContainerActivity : ComponentActivity() {
                 }) }) {
                     Text("Confirm Remove Item")
                 }
+                // Adding a Cancel button as per plan
+                Button(onClick = { finish() }) {
+                    Text("Cancel")
+                }
             }
         }
     }


### PR DESCRIPTION
Related to #6

Adds a Cancel button to the `RemoveItemFromContainerActivity` to allow users to exit the activity without removing an item.

- Implements a new Button within the `setContent` block of `RemoveItemFromContainerActivity` with the label "Cancel".
- Sets the `onClick` listener for the Cancel button to call the `finish()` method, effectively closing the activity when pressed.


